### PR TITLE
Fixed non-starting celery worker.

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/worker-start.sh
+++ b/{{cookiecutter.project_slug}}/backend/app/worker-start.sh
@@ -3,4 +3,4 @@ set -e
 
 python /app/app/celeryworker_pre_start.py
 
-celery worker -A app.worker -l info -Q main-queue -c 1
+celery -A app.worker worker -l info -Q main-queue -c 1


### PR DESCRIPTION
The config for celery changed, and the worker wouldn't start. The -A option had to be moved from the worker to celery itself.